### PR TITLE
[QATM-960]Change bdt version

### DIFF
--- a/testsAT/pom.xml
+++ b/testsAT/pom.xml
@@ -6,7 +6,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <properties>
-        <stratio-test-bdd.version>0.6.0-SNAPSHOT</stratio-test-bdd.version>
+        <stratio-test-bdd.version>0.6.0</stratio-test-bdd.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>     
     </properties>


### PR DESCRIPTION
Change bdt version for execute testAT: 0.6.0 